### PR TITLE
♻️ Simplify logic for setting oracle

### DIFF
--- a/contracts/OracleProxy.vy
+++ b/contracts/OracleProxy.vy
@@ -32,36 +32,34 @@ def __init__(_implementation: address, _factory: IFactory, _max_deviation: uint2
     """
     assert _max_deviation > 0, "Invalid max deviation"
     assert _max_deviation <= MAX_DEVIATION_BPS, "Invalid max deviation"
-    assert _factory.address != ZERO_ADDRESS
+    assert _factory.address != empty(address)
     self._validate_price_oracle(_implementation)
     self.implementation = _implementation
     self.factory = _factory
     self.max_deviation = _max_deviation
 
 @internal
-def _validate_price_oracle(_oracle: address):
+def _validate_price_oracle(_oracle: address) -> uint256:
     """
     @notice Validates the new implementation has methods implemented correctly
     """
-    assert _oracle != ZERO_ADDRESS, "Invalid address"
-    assert IPriceOracle(_oracle).price() > 0, "price() call failed"
-    assert IPriceOracle(_oracle).price_w() > 0, "price_w() call failed"
+    assert _oracle != empty(address), "Invalid address"
+
+    block_price: uint256 = IPriceOracle(_oracle).price()
+    assert block_price > 0, "price() returned invalid value"
+    assert IPriceOracle(_oracle).price_w() > 0, "price_w() returned invalid value"
+
+    return block_price
 
 @internal
-def _check_price_deviation(_old_oracle: address, _new_oracle: address):
+def _check_price_deviation(_old_oracle: address, new_price: uint256):
     """
     @notice Ensures price returned by new implementation is within acceptable bounds
     """
     old_price: uint256 = IPriceOracle(_old_oracle).price()
-    new_price: uint256 = IPriceOracle(_new_oracle).price()
 
     if old_price > 0:
-        delta: uint256 = 0
-        if old_price >= new_price:
-            delta = old_price - new_price
-        else:
-            delta = new_price - old_price
-
+        delta: uint256 = new_price - old_price if old_price < new_price else old_price - new_price
         max_delta: uint256 = old_price * self.max_deviation / 10_000
         assert delta <= max_delta, "Price deviation too high"
 
@@ -73,23 +71,8 @@ def set_price_oracle(_new_implementation: address):
     """
     assert msg.sender == self.factory.admin(), "Not authorized"
 
-    self._validate_price_oracle(_new_implementation)
-
-    # If current implementation price() is borked,
-    # skip the price deviation check
-    success: bool = False
-    response: Bytes[32] = b""
-
-    success, response = raw_call(
-        self.implementation,
-        method_id("price()"),
-        max_outsize=32,
-        is_static_call=True,
-        revert_on_failure=False
-    )
-
-    if success:
-        self._check_price_deviation(self.implementation, _new_implementation)
+    block_price: uint256 = self._validate_price_oracle(_new_implementation)
+    self._check_price_deviation(self.implementation, block_price)
 
     self.implementation = _new_implementation
     log PriceOracleSet(_new_implementation)


### PR DESCRIPTION
##  Summary

- Simplified logic for validating a given price oracle contract
- Simplified logic for checking price deviation; using one less external contract call
- Simplified `set_price_oracle` logic; using one less external contract call

## Details

<details>
<summary>expand</summary>

- `_validate_price_oracle`
  - Rather than making raw contract calls and explicitly checking for call success, it makes an implicit check by calling via the interface wrapper
  - `block_price` is returned, and will be utilised in `_check_price_deviation` to reduce number of external contract calls

- `_check_price_deviation`
  - One less external contract call is being made, a given `block_price` is used to check deviation
    - the `price` returned in a single tx will not change, so this should be fine
  - `delta` assignment simplified

- `set_price_oracle`
  - One less external contract call; `_validate_price_oracle` already calls and implicitly checks success of `price` being called
</details>
